### PR TITLE
Replace condchan with contextcond

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/evgeniums/go-utils
 go 1.18
 
 require (
+	github.com/Jille/contextcond v1.0.0
 	github.com/dchest/uniuri v1.2.0
-	github.com/evgeniums/go-condchan v0.0.0-20210623094011-3f4a45786e20
 	github.com/evgeniums/go-finish-service v0.0.0-20230710172925-6f222f893152
 	github.com/evgeniums/viper v0.0.0-20230408104246-ba679b16578b
 	github.com/gin-gonic/gin v1.9.0
@@ -89,7 +89,6 @@ require (
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.10 // indirect
-	gitlab.com/jonas.jasas/condchan v0.0.0-20190210165812-36637ad2b5bc // indirect
 	golang.org/x/arch v0.2.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Jille/contextcond v1.0.0 h1:MI7hdTKyS6CLc5DIJmyjN8iEfw7/e8HJ5ZOwTJpS9SI=
+github.com/Jille/contextcond v1.0.0/go.mod h1:aWoovvPMcWinBsm69wTnhSrCwTGtCfg4xr4Nku8WgIg=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/aymerick/raymond v2.0.2+incompatible h1:VEp3GpgdAnv9B2GFyTvqgcKvY+mfKMjPOA3SbKLtnU0=
@@ -82,8 +84,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/evgeniums/go-condchan v0.0.0-20210623094011-3f4a45786e20 h1:Jjsst0EuQqLBkWL5TmU3IxMaIVux3er11glh+ZcbSfs=
-github.com/evgeniums/go-condchan v0.0.0-20210623094011-3f4a45786e20/go.mod h1:L2V4V0gUkEZOZK8/B9HZt3kQflAioTSm7jmrc4LXJuI=
 github.com/evgeniums/go-finish-service v0.0.0-20230108111731-b6307469e51d h1:Q2HUqSRk1i48rHSinn4kaUelm2KZTcrtSzE2o394txg=
 github.com/evgeniums/go-finish-service v0.0.0-20230108111731-b6307469e51d/go.mod h1:ciz7835vOw1ztWsU0JqvCPsDyTEEZnPtpKSXR16eLTQ=
 github.com/evgeniums/go-finish-service v0.0.0-20230710172925-6f222f893152 h1:SZcI5w5X3Yua4g8MavSquwUDLIsho3KDj/zoRk/dhUY=
@@ -392,8 +392,6 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-gitlab.com/jonas.jasas/condchan v0.0.0-20190210165812-36637ad2b5bc h1:zCsu+odZEHb2f8U8WWhDgY5N5w3JCLHxuCIqVqCsLcQ=
-gitlab.com/jonas.jasas/condchan v0.0.0-20190210165812-36637ad2b5bc/go.mod h1:4JS8TdA7HSdK+x43waOdTGodqY/VKsj4w+8pWDL0E88=
 go.mongodb.org/mongo-driver v1.16.1 h1:rIVLL3q0IHM39dvE+z2ulZLp9ENZKThVfuvN/IiN4l8=
 go.mongodb.org/mongo-driver v1.16.1/go.mod h1:oB6AhJQvFQL4LEHyXi6aJzQJtBiTQHiAd83l0GdFaiw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/pkg/background_worker/background_worker.go
+++ b/pkg/background_worker/background_worker.go
@@ -6,9 +6,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Jille/contextcond"
 	"github.com/evgeniums/go-utils/pkg/logger"
 	"github.com/evgeniums/go-utils/pkg/utils"
-	"github.com/evgeniums/go-condchan"
 	"github.com/markphelps/optional"
 )
 
@@ -58,7 +58,7 @@ type BackgroundWorker struct {
 	Period int
 	Name   string
 
-	CondChan *condchan.CondChan
+	CondChan *contextcond.Cond
 	Finished chan bool
 	Stopped  atomic.Bool
 	Running  atomic.Bool
@@ -82,7 +82,7 @@ func New(log logger.Logger, jobRunner JobRunner, period int, name ...string) *Ba
 	b := &BackgroundWorker{JobRunner: jobRunner, Period: period}
 	jobRunner.SetStopper(b)
 	b.WithLoggerBase.Init(log)
-	b.CondChan = condchan.New(&sync.Mutex{})
+	b.CondChan = contextcond.NewCond(&sync.Mutex{})
 	b.Finished = make(chan bool, 1)
 	b.Name = utils.OptionalArg("", name...)
 	return b
@@ -102,26 +102,23 @@ func (w *BackgroundWorker) RunInBackground() {
 		}
 		for {
 
-			timeoutChan := time.After(time.Second * time.Duration(w.Period+1))
-			br := new(bool)
-			*br = false
+			ctx, cancel := system_context.WithTimeout(system_context.Background(), time.Second*time.Duration(w.Period+1))
+			br := false
 
 			w.CondChan.L.Lock()
-			w.CondChan.Select(func(c <-chan struct{}) {
-				select {
-				case <-c:
-					w.Logger().Debug("Background worker: signal received")
-					*br = true
-				case <-timeoutChan:
-					if !w.IsStopped() {
-						// w.Log.LogDebug("Background worker: run job")
-						w.JobRunner.RunJob()
-					}
+			if w.CondChan.WaitContext(ctx) != nil {
+				if !w.IsStopped() {
+					// w.Log.LogDebug("Background worker: run job")
+					w.JobRunner.RunJob()
 				}
-			})
+			} else {
+				w.Logger().Debug("Background worker: signal received")
+				br = true
+			}
 			w.CondChan.L.Unlock()
+			cancel()
 
-			if w.IsStopped() || *br {
+			if w.IsStopped() || br {
 				w.Logger().Debug("Background worker: break cycle")
 				break
 			}


### PR DESCRIPTION
condchan seems to be no longer maintained and has a race condition (https://gitlab.com/jonas.jasas/condchan/-/issues/1) that's not been fixed in two years.

Note that you currently are not affected by the race condition, because you only use .Broadcast() and not .Signal(). I propose to switch anyway in case someone would start using .Signal() later.